### PR TITLE
Fix shebang syntax

### DIFF
--- a/unimus-backup-exporter.sh
+++ b/unimus-backup-exporter.sh
@@ -1,4 +1,4 @@
-# !/usr/bin/env bash
+#!/usr/bin/env bash
 
 # This is a Unimus to Git API to export your backups to your Git Repo
 


### PR DESCRIPTION
On Debian 11.1.0 at least (I have not tested on other platforms), the space between the `#` and `!` characters is not recognized, and the default shell (`/bin/sh`) is used. Because of the use of more modern bash syntax, a Syntax error is raised:

```console
$ sudo ./unimus-backup-exporter.sh
./unimus-backup-exporter.sh: 7: Syntax error: "(" unexpected
```

This is resolved by removing the space. As far as I know, this would not affect compatibility with other platforms.